### PR TITLE
Restrict Indexing

### DIFF
--- a/server.js
+++ b/server.js
@@ -153,7 +153,7 @@ app.use((req, res, next) => {
 // routing for robots.txt
 app.use(robots({
     UserAgent: '*',
-    Disallow: '/cms'
+    Disallow: '/'
 }))
 
 // routing for login

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -19,7 +19,7 @@
     <meta property='og:image'
         content='https://res.cloudinary.com/drpmdiapv/image/upload/c_scale,w_1200/v1620033710/goksenia/pagePreview_398sajdu3.png' />
     <meta property='og:url' content='https://goksenia.com' />
-    <meta name="robots" content="index, follow">
+    <meta name="robots" content="noindex, nofollow">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="language" content="English">
     <meta name="revisit-after" content="10 days">


### PR DESCRIPTION
Updated robots configuration to 'noindex, nofollow' to prevent indexing and following. This is crucial since the website, serving demonstration purposes only, should not replace the customer's newer website version in search results.